### PR TITLE
 Allow any Rails 5.x version 

### DIFF
--- a/lib/mustache-js-rails/version.rb
+++ b/lib/mustache-js-rails/version.rb
@@ -1,3 +1,3 @@
 module MustacheJsRails
-  VERSION = "2.3.0"
+  VERSION = "2.3.0.1"
 end

--- a/mustache-js-rails.gemspec
+++ b/mustache-js-rails.gemspec
@@ -19,5 +19,5 @@ Gem::Specification.new do |s|
   s.files = Dir["{vendor,lib}/**/*"] + ["MIT-LICENSE", "Rakefile", "Gemfile", "README.md"]
   s.require_paths = ["lib"]
 
-  s.add_dependency 'railties', '>= 3.1', '<= 5.1'
+  s.add_dependency 'railties', '>= 3.1', '< 6'
 end


### PR DESCRIPTION
This gem allows Rails 5.1.0, but not any other 5.1.x verison, so I assume it was meant to depend on `< 5.2`.