### PR TITLE
Use alexis-renard fork with `to_html` fix

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,4 +4,4 @@
 	ignore = dirty
 [submodule "jquery.mustache.js"]
 	path = jquery.mustache.js
-	url = git@github.com:jonnyreeves/jquery-Mustache.git
+	url = git@github.com:alexis-renard/jquery-Mustache.git

--- a/vendor/assets/javascripts/jquery.mustache.js
+++ b/vendor/assets/javascripts/jquery.mustache.js
@@ -124,7 +124,7 @@
 			}
 			return '';
 		}
-		return getMustache().to_html(templateMap[templateName], templateData, templateMap);
+		return getMustache().render(templateMap[templateName], templateData, templateMap);
 	}
 
 	/**


### PR DESCRIPTION
From [`mustache.js` version 4.0.0](https://github.com/janl/mustache.js/blob/9faa18e44130b88891cb91e21c8ba0befd9547a7/CHANGELOG.md#400--16-january-2020), `.to_html` has been [removed](https://github.com/janl/mustache.js/pull/735).

`jquery.mustache.js` has not yet been updated to not use `.to_html`. There's a [PR](https://github.com/jonnyreeves/jquery-Mustache/pull/43) but it hasn't been merged.

But as things stand, doing something like `$('body').mustache('simple-hello', viewData)` will fail with the combination of `mustache.js` and `jquery.mustache.js` that ships in `mustache-js-rails` version 4.1.0. I think this will also be true of version 4.0.0 and 4.0.1, though I've not tested them myself. The error reported in DevTools is something like `Uncaught TypeError: getMustache(...).to_html is not a function`

Reverting to 3.1.0.1 fixes things for me, but here's a PR that includes the fix. If the fix gets merged in to `jquery.mustache.js` you could switch back, but it's looking close to unmaintained at this point.

This PR updates the submodule dependency and also manually updates the vendored copy of `jquery.mustache.js`: `jquery.mustache.js/src/jquery.mustache.js` has the `.to_html` change but `jquery.mustache.js/jquery.mustache.js` has not been regenerated and so we can't use `rake` to update the vendored assets.